### PR TITLE
Update README and Dockerfile for Go 1.24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:alpine AS builder
+FROM golang:1.24-alpine AS builder
 
 WORKDIR /rss_exporter
 COPY . /rss_exporter

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ It's highly configurable through a YAML file and allows for dynamic probe adjust
 
 #### Prerequisites
 
-* Go (latest stable version recommended) for building from source.
+* Go 1.24 or later for building from source.
 
 1.  Clone the repository:
     ```bash


### PR DESCRIPTION
## Summary
- require Go 1.24 or newer in README
- update Dockerfile to use golang:1.24-alpine image

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684bf8afd20c8323b8247c820703a427