### PR TITLE
Fix header timing

### DIFF
--- a/rss.go
+++ b/rss.go
@@ -193,8 +193,10 @@ func probeRSS(opts *ProbeRSSOpts, logger *logrus.Entry) {
 	logger.Traceln("making probe request")
 	resp, err := client.Do(req)
 
-	// Set received response headers time before read body
-	customTransport.ReceivedResponseHeaders()
+	if err == nil {
+		// Set received response headers time before read body
+		customTransport.ReceivedResponseHeaders()
+	}
 
 	rssProbeDurationSec.WithLabelValues(opts.Target, "dns").Set(customTransport.current.DNSDuration())
 	rssProbeDurationSec.WithLabelValues(opts.Target, "connect").Set(customTransport.current.ConnectDuration())


### PR DESCRIPTION
## Summary
- only mark header receipt when the request succeeds

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_684c045851348323b44846eb8a59ba45