### PR TITLE
Fix parseStringSlice and add tests

### DIFF
--- a/rss.go
+++ b/rss.go
@@ -370,6 +370,9 @@ func wrapFailureBody(logger *logrus.Entry, body []byte) *logrus.Entry {
 func parseStringSlice[T comparable](strs string, parseFunc func(string) (T, error)) (ret []T, err error) {
 	ret = make([]T, 0)
 	for str := range strings.SplitSeq(strs, ",") {
+		if len(str) == 0 {
+			continue
+		}
 		var sc T
 		sc, err = parseFunc(str)
 		if err != nil {

--- a/rss_test.go
+++ b/rss_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"reflect"
+	"strconv"
+	"testing"
+)
+
+func TestParseStringSlice_TrailingComma(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected []int
+	}{
+		{"200,", []int{200}},
+		{"200,301,", []int{200, 301}},
+		{",", []int{}},
+		{"", []int{}},
+	}
+	for _, tt := range tests {
+		got, err := parseStringSlice[int](tt.input, strconv.Atoi)
+		if err != nil {
+			t.Fatalf("unexpected error for %q: %v", tt.input, err)
+		}
+		if !reflect.DeepEqual(got, tt.expected) {
+			t.Errorf("for %q expected %v got %v", tt.input, tt.expected, got)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- avoid pushing empty substrings when splitting strings in `parseStringSlice`
- add tests covering valid-status parsing with trailing commas

## Testing
- `go test ./...` *(fails: flag provided but not defined)*

------
https://chatgpt.com/codex/tasks/task_e_684c05f990608323a9e5d8dea4d2ec81