### PR TITLE
Add GCP feed tests

### DIFF
--- a/gcp_feed_test.go
+++ b/gcp_feed_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/mmcdole/gofeed"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/sirupsen/logrus"
+)
+
+func loadGCPFeed(t *testing.T) *gofeed.Feed {
+	t.Helper()
+	data, err := ioutil.ReadFile("testdata/gcp_feed.atom")
+	if err != nil {
+		t.Fatalf("read feed: %v", err)
+	}
+	feed, err := gofeed.NewParser().ParseString(string(data))
+	if err != nil {
+		t.Fatalf("parse feed: %v", err)
+	}
+	return feed
+}
+
+func TestExtractServiceStatus_GCPFeed(t *testing.T) {
+	feed := loadGCPFeed(t)
+	if len(feed.Items) == 0 {
+		t.Fatal("no items in feed")
+	}
+	svc, state, active := extractServiceStatus(feed.Items[0])
+	wantSvc := strings.TrimSpace(feed.Items[0].Title)
+	if svc != wantSvc {
+		t.Errorf("service got %q want %q", svc, wantSvc)
+	}
+	if state != "service_issue" {
+		t.Errorf("state got %q want service_issue", state)
+	}
+	if !active {
+		t.Error("expected active true")
+	}
+}
+
+func TestUpdateServiceStatus_GCPFeed(t *testing.T) {
+	// serve the feed via test server
+	data, err := ioutil.ReadFile("testdata/gcp_feed.atom")
+	if err != nil {
+		t.Fatalf("read feed: %v", err)
+	}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(data)
+	}))
+	defer ts.Close()
+
+	serviceStatusGauge.Reset()
+
+	cfg := ServiceFeed{Name: "gcp", URL: ts.URL, Interval: 0}
+	updateServiceStatus(cfg, logrus.NewEntry(logrus.New()))
+
+	if val := testutil.ToFloat64(serviceStatusGauge.WithLabelValues("gcp", "service_issue")); val != 1 {
+		t.Errorf("service_issue gauge = %v, want 1", val)
+	}
+	if val := testutil.ToFloat64(serviceStatusGauge.WithLabelValues("gcp", "ok")); val != 0 {
+		t.Errorf("ok gauge = %v, want 0", val)
+	}
+	if val := testutil.ToFloat64(serviceStatusGauge.WithLabelValues("gcp", "outage")); val != 0 {
+		t.Errorf("outage gauge = %v, want 0", val)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/kr/text v0.2.0 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mmcdole/goxpp v1.1.1-0.20240225020742-a0c311522b23 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/mmcdole/gofeed"
@@ -49,7 +50,10 @@ var (
 func init() {
 	var configFile string
 	flag.StringVar(&configFile, "config", defaultConfigFile, "path to config file")
-	flag.Parse()
+	// Skip parsing if running under "go test".
+	if !strings.HasSuffix(os.Args[0], ".test") {
+		flag.Parse()
+	}
 
 	logrus.SetLevel(logrus.InfoLevel)
 	logrus.SetOutput(os.Stdout)
@@ -64,7 +68,11 @@ func init() {
 	var err error
 	appConfig, err = loadConfig(configFile)
 	if err != nil {
-		logrus.Fatalf("load config failed: %v", err)
+		if strings.HasSuffix(os.Args[0], ".test") {
+			logrus.Warnf("load config failed: %v", err)
+		} else {
+			logrus.Fatalf("load config failed: %v", err)
+		}
 	}
 
 	prometheus.MustRegister(serviceStatusGauge)

--- a/testdata/gcp_feed.atom
+++ b/testdata/gcp_feed.atom
@@ -1,0 +1,17 @@
+<feed xmlns="http://www.w3.org/2005/Atom">
+<title>Google Cloud Service Health Updates</title>
+<updated>2025-06-13T06:34:31+00:00</updated>
+<link href="https://status.cloud.google.com/" rel="alternate" type="text/html"/>
+<link href="https://status.cloud.google.com/en/feed.atom" rel="self"/>
+<author>
+<name>Google Cloud</name>
+</author>
+<id>https://status.cloud.google.com/</id>
+<entry>
+<title>RESOLVED: Multiple GCP products are experiencing Service issues</title>
+<link href="https://status.cloud.google.com/incidents/ow5i3PPK96RduMcb1SsW" rel="alternate" type="text/html"/>
+<id>tag:status.cloud.google.com,2025:feed:ow5i3PPK96RduMcb1SsW.d7LGbBM4QxfQYfr55s1Q</id>
+<updated>2025-06-13T06:34:31+00:00</updated>
+<summary type="html"><p>Incident began at <strong>2025-06-12 10:51</strong> and ended at <strong>2025-06-12 18:18</strong> <span>(all times are <strong>US/Pacific</strong>).</span></p></summary>
+</entry>
+</feed>


### PR DESCRIPTION
## Summary
- add atom feed fixture
- test extractServiceStatus and updateServiceStatus using GCP feed
- allow running tests without config file

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684c077cc8248323bd7da8ac07e5fa62