### PR TITLE
Add AWS feed monitoring option

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ The exporter is configured using a YAML file (default: `config.yml`).
 ### Command-line Flags
 
   * `-config <path>`: Path to the configuration file. Default: `config.yml`.
+  * `-enable-aws-feeds`: Automatically monitor built-in AWS service RSS feeds.
 
 ### Configuration Options
 

--- a/aws_feeds.go
+++ b/aws_feeds.go
@@ -1,0 +1,31 @@
+package main
+
+import "fmt"
+
+// defaultAWSServiceFeeds returns a list of AWS service RSS feeds.
+func defaultAWSServiceFeeds() []ServiceFeed {
+	services := []string{
+		"apigateway",
+		"ec2",
+		"s3",
+		"rds",
+		"lambda",
+		"dynamodb",
+	}
+	regions := []string{
+		"us-east-1",
+		"us-west-2",
+		"eu-central-1",
+		"eu-west-1",
+	}
+
+	feeds := make([]ServiceFeed, 0, len(services)*len(regions))
+	for _, svc := range services {
+		for _, region := range regions {
+			name := fmt.Sprintf("aws_%s_%s", svc, region)
+			url := fmt.Sprintf("https://status.aws.amazon.com/rss/%s-%s.rss", svc, region)
+			feeds = append(feeds, ServiceFeed{Name: name, URL: url, Interval: 300})
+		}
+	}
+	return feeds
+}

--- a/aws_feeds_test.go
+++ b/aws_feeds_test.go
@@ -1,0 +1,21 @@
+package main
+
+import "testing"
+
+func TestDefaultAWSServiceFeeds(t *testing.T) {
+	feeds := defaultAWSServiceFeeds()
+	if len(feeds) == 0 {
+		t.Fatal("no feeds returned")
+	}
+	want := "https://status.aws.amazon.com/rss/apigateway-eu-central-1.rss"
+	found := false
+	for _, f := range feeds {
+		if f.URL == want {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected feed %s not found", want)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -39,6 +39,7 @@ type ServiceFeed struct {
 
 var (
 	appConfig Config
+	enableAWS bool
 	logLevels = map[string]logrus.Level{
 		"trace": logrus.TraceLevel,
 		"debug": logrus.DebugLevel,
@@ -50,6 +51,7 @@ var (
 func init() {
 	var configFile string
 	flag.StringVar(&configFile, "config", defaultConfigFile, "path to config file")
+	flag.BoolVar(&enableAWS, "enable-aws-feeds", false, "monitor default AWS service feeds")
 	// Skip parsing if running under "go test".
 	if !strings.HasSuffix(os.Args[0], ".test") {
 		flag.Parse()
@@ -73,6 +75,10 @@ func init() {
 		} else {
 			logrus.Fatalf("load config failed: %v", err)
 		}
+	}
+
+	if enableAWS {
+		appConfig.Services = append(appConfig.Services, defaultAWSServiceFeeds()...)
 	}
 
 	prometheus.MustRegister(serviceStatusGauge)


### PR DESCRIPTION
## Summary
- provide default AWS service feeds
- add `-enable-aws-feeds` flag
- append AWS feeds to config when enabled
- test AWS feed list generation

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684c0b2a2b7c832397f2b3d425f9dc51