### PR TITLE
Update AWS feed URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The exporter is configured using a YAML file (default: `config.yml`).
 ### Command-line Flags
 
   * `-config <path>`: Path to the configuration file. Default: `config.yml`.
-  * `-enable-aws-feeds`: Automatically monitor built-in AWS service RSS feeds.
+  * `-enable-aws-feeds`: Automatically monitor built-in AWS status RSS feeds. The exporter now tracks the consolidated `multipleservices-<region>` feeds provided by AWS.
 
 ### Configuration Options
 

--- a/aws_feeds.go
+++ b/aws_feeds.go
@@ -2,30 +2,57 @@ package main
 
 import "fmt"
 
-// defaultAWSServiceFeeds returns a list of AWS service RSS feeds.
+// defaultAWSServiceFeeds returns a list of AWS region RSS feeds.
+//
+// AWS consolidated its status RSS feeds and provides a single
+// "multipleservices" feed per region. This function returns all
+// currently available regional feeds.
 func defaultAWSServiceFeeds() []ServiceFeed {
-	services := []string{
-		"apigateway",
-		"ec2",
-		"s3",
-		"rds",
-		"lambda",
-		"dynamodb",
-	}
 	regions := []string{
 		"us-east-1",
+		"us-east-2",
+		"us-west-1",
 		"us-west-2",
+		"ca-central-1",
+		"ca-west-1",
+		"sa-east-1",
 		"eu-central-1",
+		"eu-central-2",
+		"eu-north-1",
+		"eu-south-1",
+		"eu-south-2",
 		"eu-west-1",
+		"eu-west-2",
+		"eu-west-3",
+		"ap-east-1",
+		"ap-east-2",
+		"ap-northeast-1",
+		"ap-northeast-2",
+		"ap-northeast-3",
+		"ap-south-1",
+		"ap-south-2",
+		"ap-southeast-1",
+		"ap-southeast-2",
+		"ap-southeast-3",
+		"ap-southeast-4",
+		"ap-southeast-5",
+		"ap-southeast-7",
+		"me-central-1",
+		"me-south-1",
+		"af-south-1",
+		"il-central-1",
+		"mx-central-1",
+		"us-gov-east-1",
+		"us-gov-west-1",
+		"cn-north-1",
+		"cn-northwest-1",
 	}
 
-	feeds := make([]ServiceFeed, 0, len(services)*len(regions))
-	for _, svc := range services {
-		for _, region := range regions {
-			name := fmt.Sprintf("aws_%s_%s", svc, region)
-			url := fmt.Sprintf("https://status.aws.amazon.com/rss/%s-%s.rss", svc, region)
-			feeds = append(feeds, ServiceFeed{Name: name, URL: url, Interval: 300})
-		}
+	feeds := make([]ServiceFeed, 0, len(regions))
+	for _, region := range regions {
+		name := fmt.Sprintf("aws_%s", region)
+		url := fmt.Sprintf("https://status.aws.amazon.com/rss/multipleservices-%s.rss", region)
+		feeds = append(feeds, ServiceFeed{Name: name, URL: url, Interval: 300})
 	}
 	return feeds
 }

--- a/aws_feeds_test.go
+++ b/aws_feeds_test.go
@@ -7,7 +7,7 @@ func TestDefaultAWSServiceFeeds(t *testing.T) {
 	if len(feeds) == 0 {
 		t.Fatal("no feeds returned")
 	}
-	want := "https://status.aws.amazon.com/rss/apigateway-eu-central-1.rss"
+	want := "https://status.aws.amazon.com/rss/multipleservices-eu-central-1.rss"
 	found := false
 	for _, f := range feeds {
 		if f.URL == want {


### PR DESCRIPTION
## Summary
- use new consolidated AWS `multipleservices` feeds
- expand default AWS feed list to all regions
- update README flag docs
- update tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684c1af8f8a08323859dd160fe457346