### PR TITLE
Handle resolved incidents

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ It's highly configurable through a YAML file and allows for dynamic probe adjust
     * Overall probe success status.
     * Detailed probe duration (DNS lookup, TCP connection, TLS handshake, time to first byte, content transfer).
 * Feed content size.
-* Detects service incident keywords ("SERVICE ISSUE", "OUTAGE") and exposes service status metrics.
+* Detects service incident keywords ("SERVICE ISSUE", "OUTAGE"). Incidents labeled
+  "RESOLVED" reset the service status to `ok`.
 * Continuously monitors configured service feeds and updates their status metrics.
 * Configuration via a YAML file for listener settings, logging, default probe behavior.
 * Customizable probe behavior per request using HTTP query parameters (e.g., target URL, timeout, valid HTTP status codes).

--- a/gcp_feed_test.go
+++ b/gcp_feed_test.go
@@ -35,11 +35,11 @@ func TestExtractServiceStatus_GCPFeed(t *testing.T) {
 	if svc != wantSvc {
 		t.Errorf("service got %q want %q", svc, wantSvc)
 	}
-	if state != "service_issue" {
-		t.Errorf("state got %q want service_issue", state)
+	if state != "resolved" {
+		t.Errorf("state got %q want resolved", state)
 	}
-	if !active {
-		t.Error("expected active true")
+	if active {
+		t.Error("expected active false")
 	}
 }
 
@@ -59,11 +59,11 @@ func TestUpdateServiceStatus_GCPFeed(t *testing.T) {
 	cfg := ServiceFeed{Name: "gcp", URL: ts.URL, Interval: 0}
 	updateServiceStatus(cfg, logrus.NewEntry(logrus.New()))
 
-	if val := testutil.ToFloat64(serviceStatusGauge.WithLabelValues("gcp", "service_issue")); val != 1 {
-		t.Errorf("service_issue gauge = %v, want 1", val)
+	if val := testutil.ToFloat64(serviceStatusGauge.WithLabelValues("gcp", "ok")); val != 1 {
+		t.Errorf("ok gauge = %v, want 1", val)
 	}
-	if val := testutil.ToFloat64(serviceStatusGauge.WithLabelValues("gcp", "ok")); val != 0 {
-		t.Errorf("ok gauge = %v, want 0", val)
+	if val := testutil.ToFloat64(serviceStatusGauge.WithLabelValues("gcp", "service_issue")); val != 0 {
+		t.Errorf("service_issue gauge = %v, want 0", val)
 	}
 	if val := testutil.ToFloat64(serviceStatusGauge.WithLabelValues("gcp", "outage")); val != 0 {
 		t.Errorf("outage gauge = %v, want 0", val)

--- a/rss.go
+++ b/rss.go
@@ -402,12 +402,12 @@ func parseQuery(q *url.Values, key string, defVal int) (v int, err error) {
 func extractServiceStatus(item *gofeed.Item) (service string, state string, active bool) {
 	text := strings.ToUpper(strings.TrimSpace(item.Title + " " + item.Description))
 	switch {
-	case strings.Contains(text, "SERVICE ISSUE"):
-		state = "service_issue"
-	case strings.Contains(text, "OUTAGE"):
-		state = "outage"
 	case strings.Contains(text, "RESOLVED"):
 		state = "resolved"
+	case strings.Contains(text, "OUTAGE"):
+		state = "outage"
+	case strings.Contains(text, "SERVICE ISSUE"):
+		state = "service_issue"
 	}
 
 	if state == "" {


### PR DESCRIPTION
## Summary
- treat `RESOLVED` entries as cleared service issues
- update tests accordingly
- document that "RESOLVED" resets status to `ok`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684c2c0e57788323ba5e188a657c02cc