### PR TITLE
Add AWS Athena issue feed support

### DIFF
--- a/aws_feed_test.go
+++ b/aws_feed_test.go
@@ -19,6 +19,15 @@ func loadAWSFeed(t *testing.T) []byte {
 	return data
 }
 
+func loadAWSAthenaIssueFeed(t *testing.T) []byte {
+	t.Helper()
+	data, err := ioutil.ReadFile("testdata/aws_athena_us_west_2_issue.rss")
+	if err != nil {
+		t.Fatalf("read feed: %v", err)
+	}
+	return data
+}
+
 func TestUpdateServiceStatus_AWSFeed(t *testing.T) {
 	data := loadAWSFeed(t)
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -38,6 +47,29 @@ func TestUpdateServiceStatus_AWSFeed(t *testing.T) {
 		t.Errorf("service_issue gauge = %v, want 0", val)
 	}
 	if val := testutil.ToFloat64(serviceStatusGauge.WithLabelValues("aws", "outage")); val != 0 {
+		t.Errorf("outage gauge = %v, want 0", val)
+	}
+}
+
+func TestUpdateServiceStatus_AWSAthenaIssueFeed(t *testing.T) {
+	data := loadAWSAthenaIssueFeed(t)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(data)
+	}))
+	defer ts.Close()
+
+	serviceStatusGauge.Reset()
+
+	cfg := ServiceFeed{Name: "aws-athena", URL: ts.URL, Interval: 0}
+	updateServiceStatus(cfg, logrus.NewEntry(logrus.New()))
+
+	if val := testutil.ToFloat64(serviceStatusGauge.WithLabelValues("aws-athena", "ok")); val != 0 {
+		t.Errorf("ok gauge = %v, want 0", val)
+	}
+	if val := testutil.ToFloat64(serviceStatusGauge.WithLabelValues("aws-athena", "service_issue")); val != 1 {
+		t.Errorf("service_issue gauge = %v, want 1", val)
+	}
+	if val := testutil.ToFloat64(serviceStatusGauge.WithLabelValues("aws-athena", "outage")); val != 0 {
 		t.Errorf("outage gauge = %v, want 0", val)
 	}
 }

--- a/aws_feeds.go
+++ b/aws_feeds.go
@@ -15,5 +15,10 @@ func defaultAWSServiceFeeds() []ServiceFeed {
 			URL:      "https://status.aws.amazon.com/rss/connect-eu-west-2.rss",
 			Interval: 300,
 		},
+		{
+			Name:     "aws_athena_us-west-2",
+			URL:      "https://status.aws.amazon.com/rss/athena-us-west-2.rss",
+			Interval: 300,
+		},
 	}
 }

--- a/aws_feeds_test.go
+++ b/aws_feeds_test.go
@@ -4,13 +4,14 @@ import "testing"
 
 func TestDefaultAWSServiceFeeds(t *testing.T) {
 	feeds := defaultAWSServiceFeeds()
-	if len(feeds) != 2 {
-		t.Fatalf("expected 2 feeds got %d", len(feeds))
+	if len(feeds) != 3 {
+		t.Fatalf("expected 3 feeds got %d", len(feeds))
 	}
 
 	want := map[string]string{
 		"aws_apigateway_eu-central-1": "https://status.aws.amazon.com/rss/apigateway-eu-central-1.rss",
 		"aws_connect_eu-west-2":       "https://status.aws.amazon.com/rss/connect-eu-west-2.rss",
+		"aws_athena_us-west-2":        "https://status.aws.amazon.com/rss/athena-us-west-2.rss",
 	}
 
 	for _, f := range feeds {

--- a/rss.go
+++ b/rss.go
@@ -406,7 +406,7 @@ func extractServiceStatus(item *gofeed.Item) (service string, state string, acti
 		state = "resolved"
 	case strings.Contains(text, "OUTAGE"):
 		state = "outage"
-	case strings.Contains(text, "SERVICE ISSUE"):
+	case strings.Contains(text, "SERVICE ISSUE"), strings.Contains(text, "SERVICE IMPACT"):
 		state = "service_issue"
 	}
 

--- a/testdata/aws_athena_us_west_2_issue.rss
+++ b/testdata/aws_athena_us_west_2_issue.rss
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title><![CDATA[Amazon Athena (Oregon) Service Status]]></title>
+    <link>https://status.aws.amazon.com/</link>
+    <language>en-us</language>
+    <lastBuildDate>Fri, 13 Jun 2025 10:02:26 PDT</lastBuildDate>
+    <generator>AWS Service Health Dashboard RSS Generator</generator>
+    <description><![CDATA[Receive the most recent update for events affecting the overall availability of Amazon Athena in Oregon. To receive personalized events about your specific AWS accounts and resources, try the aws.health source in EventBridge or the Health API.]]></description>
+    <ttl>5</ttl>
+
+    <item>
+      <title><![CDATA[Service impact: Increased Queue Processing Time]]></title>
+      <link>https://status.aws.amazon.com/</link>
+      <pubDate>Fri, 13 Jun 2025 09:38:42 PDT</pubDate>
+      <guid isPermaLink="false">https://status.aws.amazon.com/#athena-us-west-2_1749832722</guid>
+      <description><![CDATA[We are investigating increased processing times for queued queries in the US-WEST-2 Region. ]]></description>
+    </item>
+
+  </channel>
+</rss>


### PR DESCRIPTION
## Summary
- expand AWS service status parser to detect `SERVICE IMPACT`
- monitor Athena US West 2 in the default AWS feeds
- add an Athena sample RSS feed
- test the Athena alert detection
- update default feed tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684c5a52a65c83238941efb1916c587a