### PR TITLE
Add service issue info metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,3 +161,5 @@ All metrics exposed by the exporter are prefixed with `rss_exporter_`. The `targ
   * `rss_exporter_service_status{service="<name>",state="<status>"}` (Gauge):
     Tracks the current state of each configured service feed. `state` can be
     `ok`, `service_issue`, or `outage`.
+  * `rss_exporter_service_issue_info{service="<name>",title="<item_title>",link="<item_link>",guid="<item_guid>"}` (Gauge):
+    Set to `1` when a service has an active issue. The metric is removed once the service returns to `ok`.

--- a/rss.go
+++ b/rss.go
@@ -39,6 +39,14 @@ var (
 		},
 		[]string{"service", "state"},
 	)
+	serviceIssueInfo = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      "service_issue_info",
+			Help:      "Details for the currently active service issue.",
+		},
+		[]string{"service", "title", "link", "guid"},
+	)
 )
 
 type ProbeRSSOpts struct {


### PR DESCRIPTION
## Summary
- track RSS service issue information via a new GaugeVec
- register metric at startup
- expose metric when incidents are parsed
- document `rss_exporter_service_issue_info`
- test metric appears when parsing AWS Athena issue feed

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684c60c1db388323b7f905e5bc0e084c