### PR TITLE
Expose response headers as labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,13 +113,15 @@ To probe an RSS feed, send a GET request to the configured `probe_path`. The beh
       * Example: `fail_on_empty_items=1`
   * `peek_resp_headers_log` (string, optional): A **comma-separated** list of response header names. The first value of each specified header will be logged. Header names are case-insensitive (standard HTTP header behavior, logged keys are modified).
       * Example: `peek_resp_headers_log=Content-Type,Last-Modified,ETag`
+  * `peek_resp_headers_labels` (string, optional): A **comma-separated** list of response header names. The first value of each specified header will be exposed as labels on the `probe_headers_info` metric.
+      * Example: `peek_resp_headers_labels=Server,ETag`
 
 ### Example Probe URL
 
 Assuming the exporter is running on `localhost:9191` with the default `probe_path` (`/probe`):
 
 ```
-http://localhost:9191/probe?target=https://rss.example.com/files/sample-rss-2.xml&timeout=20&valid_status=200&fail_on_empty_items=1&peek_resp_headers_log=Server,Content-Type
+http://localhost:9191/probe?target=https://rss.example.com/files/sample-rss-2.xml&timeout=20&valid_status=200&fail_on_empty_items=1&peek_resp_headers_log=Server,Content-Type&peek_resp_headers_labels=Server
 ```
 
 This request will:
@@ -158,6 +160,8 @@ All metrics exposed by the exporter are prefixed with `rss_exporter_`. The `targ
 
   * `rss_exporter_feed_content_size_bytes{target="<feed_url>"}` (Gauge):
     The size of the fetched RSS feed content in bytes.
+  * `rss_exporter_probe_headers_info{target="<feed_url>",<header_label>="<value>",...}` (Gauge):
+    Exposes the first value of each header listed in `peek_resp_headers_labels` as labels. Always set to `1` if present.
   * `rss_exporter_service_status{service="<name>",state="<status>"}` (Gauge):
     Tracks the current state of each configured service feed. `state` can be
     `ok`, `service_issue`, or `outage`.

--- a/peek_headers_labels_test.go
+++ b/peek_headers_labels_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestProbeHeadersLabels(t *testing.T) {
+	data := loadAWSFeed(t)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Server", "testserver")
+		w.Header().Set("ETag", "abc123")
+		w.Write(data)
+	}))
+	defer ts.Close()
+
+	req := httptest.NewRequest("GET", fmt.Sprintf("/probe?target=%s&peek_resp_headers_labels=Server,ETag", url.QueryEscape(ts.URL)), nil)
+	rr := httptest.NewRecorder()
+
+	probeHandler(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("unexpected status %d", rr.Code)
+	}
+
+	body := rr.Body.String()
+	if !strings.Contains(body, "rss_exporter_probe_headers_info") {
+		t.Fatalf("metric missing in response: %s", body)
+	}
+
+	expected := fmt.Sprintf("rss_exporter_probe_headers_info{ETag=\"abc123\",Server=\"testserver\",target=\"%s\"} 1", ts.URL)
+	if !strings.Contains(body, expected) {
+		t.Errorf("expected metric %q not found in response. body: %s", expected, body)
+	}
+}


### PR DESCRIPTION
## Summary
- expose selected response headers on `probe_headers_info` metric
- allow `peek_resp_headers_labels` query parameter
- document response header label support in README
- test header label metric

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684c620924088323b4e551432acf167e