### PR TITLE
Handle resolved GCP issues

### DIFF
--- a/gcp_feed_test.go
+++ b/gcp_feed_test.go
@@ -25,6 +25,32 @@ func loadGCPFeed(t *testing.T) *gofeed.Feed {
 	return feed
 }
 
+func loadGCPUpdateFeed(t *testing.T) *gofeed.Feed {
+	t.Helper()
+	data, err := ioutil.ReadFile("testdata/gcp_update_resolved.atom")
+	if err != nil {
+		t.Fatalf("read feed: %v", err)
+	}
+	feed, err := gofeed.NewParser().ParseString(string(data))
+	if err != nil {
+		t.Fatalf("parse feed: %v", err)
+	}
+	return feed
+}
+
+func loadGCPResolvedThenUpdateFeed(t *testing.T) *gofeed.Feed {
+	t.Helper()
+	data, err := ioutil.ReadFile("testdata/gcp_resolved_then_update.atom")
+	if err != nil {
+		t.Fatalf("read feed: %v", err)
+	}
+	feed, err := gofeed.NewParser().ParseString(string(data))
+	if err != nil {
+		t.Fatalf("parse feed: %v", err)
+	}
+	return feed
+}
+
 func TestExtractServiceStatus_GCPFeed(t *testing.T) {
 	feed := loadGCPFeed(t)
 	if len(feed.Items) == 0 {
@@ -46,6 +72,46 @@ func TestExtractServiceStatus_GCPFeed(t *testing.T) {
 func TestUpdateServiceStatus_GCPFeed(t *testing.T) {
 	// serve the feed via test server
 	data, err := ioutil.ReadFile("testdata/gcp_feed.atom")
+	if err != nil {
+		t.Fatalf("read feed: %v", err)
+	}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(data)
+	}))
+	defer ts.Close()
+
+	serviceStatusGauge.Reset()
+
+	cfg := ServiceFeed{Name: "gcp", URL: ts.URL, Interval: 0}
+	updateServiceStatus(cfg, logrus.NewEntry(logrus.New()))
+
+	if val := testutil.ToFloat64(serviceStatusGauge.WithLabelValues("gcp", "ok")); val != 1 {
+		t.Errorf("ok gauge = %v, want 1", val)
+	}
+	if val := testutil.ToFloat64(serviceStatusGauge.WithLabelValues("gcp", "service_issue")); val != 0 {
+		t.Errorf("service_issue gauge = %v, want 0", val)
+	}
+	if val := testutil.ToFloat64(serviceStatusGauge.WithLabelValues("gcp", "outage")); val != 0 {
+		t.Errorf("outage gauge = %v, want 0", val)
+	}
+}
+
+func TestExtractServiceStatus_GCPUpdateFeed(t *testing.T) {
+	feed := loadGCPUpdateFeed(t)
+	if len(feed.Items) == 0 {
+		t.Fatal("no items in feed")
+	}
+	_, state, active := extractServiceStatus(feed.Items[0])
+	if state != "service_issue" {
+		t.Errorf("state got %q want service_issue", state)
+	}
+	if !active {
+		t.Error("expected active true")
+	}
+}
+
+func TestUpdateServiceStatus_GCPResolvedThenUpdate(t *testing.T) {
+	data, err := ioutil.ReadFile("testdata/gcp_resolved_then_update.atom")
 	if err != nil {
 		t.Fatalf("read feed: %v", err)
 	}

--- a/metrics.go
+++ b/metrics.go
@@ -29,7 +29,7 @@ var (
 )
 
 func extractServiceStatus(item *gofeed.Item) (service string, state string, active bool) {
-	text := strings.ToUpper(strings.TrimSpace(item.Title + " " + item.Description))
+	text := strings.ToUpper(strings.TrimSpace(item.Title))
 	switch {
 	case strings.Contains(text, "RESOLVED"):
 		state = "resolved"

--- a/testdata/gcp_resolved_then_update.atom
+++ b/testdata/gcp_resolved_then_update.atom
@@ -1,0 +1,24 @@
+<feed xmlns="http://www.w3.org/2005/Atom">
+<title>Google Cloud Service Health Updates</title>
+<updated>2025-06-13T15:26:55+00:00</updated>
+<link href="https://status.cloud.google.com/" rel="alternate" type="text/html"></link>
+<link href="https://status.cloud.google.com/en/feed.atom" rel="self"></link>
+<author>
+  <name>Google Cloud</name>
+</author>
+<id>https://status.cloud.google.com/</id>
+<entry>
+  <title>RESOLVED: Multiple GCP products are experiencing Service issues</title>
+  <link href="https://status.cloud.google.com/incidents/ow5i3PPK96RduMcb1SsW" rel="alternate" type="text/html"></link>
+  <id>tag:status.cloud.google.com,2025:feed:ow5i3PPK96RduMcb1SsW.d7LGbBM4QxfQYfr55s1Q</id>
+  <updated>2025-06-13T15:26:55+00:00</updated>
+  <summary type="html"><p>Incident began at <strong>2025-06-12 10:51</strong> and ended at <strong>2025-06-12 18:18</strong> <span>(all times are <strong>US/Pacific</strong>).</span></p></summary>
+</entry>
+<entry>
+  <title>UPDATE: Multiple GCP products are experiencing Service issues</title>
+  <link href="https://status.cloud.google.com/incidents/ow5i3PPK96RduMcb1SsW" rel="alternate" type="text/html"></link>
+  <id>tag:status.cloud.google.com,2025:feed:ow5i3PPK96RduMcb1SsW.EYS5NxprdG6G2ZSxsx1K</id>
+  <updated>2025-06-13T01:27:32+00:00</updated>
+  <summary type="html"><p><strong>Vertex AI Online Prediction:</strong> The issue causing elevated 5xx errors with some Model Garden models was fully resolved as of 17:05 PDT. Vertex AI serving is now back to normal in all regions except europe-west1 and asia-southeast1.</p></summary>
+</entry>
+</feed>

--- a/testdata/gcp_update_resolved.atom
+++ b/testdata/gcp_update_resolved.atom
@@ -1,0 +1,17 @@
+<feed xmlns="http://www.w3.org/2005/Atom">
+<title>Google Cloud Service Health Updates</title>
+<updated>2025-06-13T01:27:32+00:00</updated>
+<link href="https://status.cloud.google.com/" rel="alternate" type="text/html"/>
+<link href="https://status.cloud.google.com/en/feed.atom" rel="self"/>
+<author>
+<name>Google Cloud</name>
+</author>
+<id>https://status.cloud.google.com/</id>
+<entry>
+<title>UPDATE: Multiple GCP products are experiencing Service issues</title>
+<link href="https://status.cloud.google.com/incidents/ow5i3PPK96RduMcb1SsW" rel="alternate" type="text/html"/>
+<id>tag:status.cloud.google.com,2025:feed:ow5i3PPK96RduMcb1SsW.EYS5NxprdG6G2ZSxsx1K</id>
+<updated>2025-06-13T01:27:32+00:00</updated>
+<summary type="html"><p><strong>Vertex AI Online Prediction:</strong> The issue causing elevated 5xx errors with some Model Garden models was fully resolved as of 17:05 PDT. Vertex AI serving is now back to normal in all regions except europe-west1 and asia-southeast1.</p></summary>
+</entry>
+</feed>


### PR DESCRIPTION
## Summary
- rely only on the entry title when detecting incident state
- ignore older GCP updates once a resolved entry is seen
- add a multi-item GCP feed and test

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684c6d4baa1c832390cc7c2ace2fa82d