### PR TITLE
Handle resolved OpenAI incidents

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -29,13 +29,21 @@ var (
 )
 
 func extractServiceStatus(item *gofeed.Item) (service string, state string, active bool) {
-	text := strings.ToUpper(strings.TrimSpace(item.Title))
+	upper := func(s string) string {
+		return strings.ToUpper(strings.TrimSpace(s))
+	}
+
+	title := upper(item.Title)
+	summary := upper(item.Description)
+	content := upper(item.Content)
+	combined := strings.Join([]string{title, summary, content}, " ")
+
 	switch {
-	case strings.Contains(text, "RESOLVED"):
+	case strings.Contains(combined, "STATUS: RESOLVED") || strings.Contains(title, "RESOLVED"):
 		state = "resolved"
-	case strings.Contains(text, "OUTAGE"):
+	case strings.Contains(combined, "OUTAGE"):
 		state = "outage"
-	case strings.Contains(text, "SERVICE ISSUE"), strings.Contains(text, "SERVICE IMPACT"):
+	case strings.Contains(combined, "SERVICE ISSUE") || strings.Contains(combined, "SERVICE IMPACT"):
 		state = "service_issue"
 	}
 	if state == "" {

--- a/openai_feed_test.go
+++ b/openai_feed_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/mmcdole/gofeed"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/sirupsen/logrus"
+)
+
+func loadOpenAIResolvedFeed(t *testing.T) *gofeed.Feed {
+	t.Helper()
+	data, err := ioutil.ReadFile("testdata/openai_resolved.atom")
+	if err != nil {
+		t.Fatalf("read feed: %v", err)
+	}
+	feed, err := gofeed.NewParser().ParseString(string(data))
+	if err != nil {
+		t.Fatalf("parse feed: %v", err)
+	}
+	return feed
+}
+
+func TestExtractServiceStatus_OpenAIResolved(t *testing.T) {
+	feed := loadOpenAIResolvedFeed(t)
+	if len(feed.Items) == 0 {
+		t.Fatal("no items in feed")
+	}
+	_, state, active := extractServiceStatus(feed.Items[0])
+	if state != "resolved" {
+		t.Errorf("state got %q want resolved", state)
+	}
+	if active {
+		t.Error("expected active false")
+	}
+}
+
+func TestUpdateServiceStatus_OpenAIResolved(t *testing.T) {
+	data, err := ioutil.ReadFile("testdata/openai_resolved.atom")
+	if err != nil {
+		t.Fatalf("read feed: %v", err)
+	}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(data)
+	}))
+	defer ts.Close()
+
+	serviceStatusGauge.Reset()
+
+	cfg := ServiceFeed{Name: "openai", URL: ts.URL, Interval: 0}
+	updateServiceStatus(cfg, logrus.NewEntry(logrus.New()))
+
+	if val := testutil.ToFloat64(serviceStatusGauge.WithLabelValues("openai", "ok")); val != 1 {
+		t.Errorf("ok gauge = %v, want 1", val)
+	}
+	if val := testutil.ToFloat64(serviceStatusGauge.WithLabelValues("openai", "service_issue")); val != 0 {
+		t.Errorf("service_issue gauge = %v, want 0", val)
+	}
+	if val := testutil.ToFloat64(serviceStatusGauge.WithLabelValues("openai", "outage")); val != 0 {
+		t.Errorf("outage gauge = %v, want 0", val)
+	}
+}

--- a/testdata/openai_resolved.atom
+++ b/testdata/openai_resolved.atom
@@ -1,0 +1,12 @@
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>OpenAI status</title>
+  <updated>2025-06-13T19:09:11.209Z</updated>
+  <entry>
+    <title type="html"><![CDATA[Log in issues]]></title>
+    <id>https://status.openai.com//incidents/01JXJPWKHTPB8Y3B6MBTCAE76X</id>
+    <link href="https://status.openai.com//incidents/01JXJPWKHTPB8Y3B6MBTCAE76X"/>
+    <updated>2025-06-12T20:05:00.000Z</updated>
+    <summary type="html"><![CDATA[<b>Status: Resolved</b><br/><br/>All impacted services have now fully recovered.]]></summary>
+    <content type="html"><![CDATA[<b>Status: Resolved</b><br/><br/>All impacted services have now fully recovered.]]></content>
+  </entry>
+</feed>


### PR DESCRIPTION
## Summary
- expand service status detection to look at RSS item descriptions and content
- add OpenAI feed snippet showing a resolved incident
- test resolved OpenAI incidents

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684c770e8100832382831eaa5595768c