### PR TITLE
Expose AWS service name/region labels

### DIFF
--- a/aws_feed_test.go
+++ b/aws_feed_test.go
@@ -98,6 +98,8 @@ func TestServiceIssueInfoMetric(t *testing.T) {
 
 	val := testutil.ToFloat64(serviceIssueInfo.WithLabelValues(
 		"aws-athena",
+		"athena",
+		"us-west-2",
 		"Service impact: Increased Queue Processing Time",
 		"https://status.aws.amazon.com/",
 		"https://status.aws.amazon.com/#athena-us-west-2_1749832722",
@@ -164,6 +166,8 @@ func TestUpdateServiceStatus_AWSOutageFeed(t *testing.T) {
 
 	val := testutil.ToFloat64(serviceIssueInfo.WithLabelValues(
 		"aws-ec2",
+		"ec2",
+		"us-west-2",
 		"OUTAGE: Unable to Launch Instances",
 		"https://status.aws.amazon.com/",
 		"https://status.aws.amazon.com/#ec2-us-west-2_outage",

--- a/aws_guid.go
+++ b/aws_guid.go
@@ -1,0 +1,29 @@
+package main
+
+import "strings"
+
+// parseAWSGUID extracts the AWS service name and region from a GUID string.
+// The GUID is expected to contain a fragment like "#service-region_xxx".
+func parseAWSGUID(guid string) (serviceName, region string) {
+	if idx := strings.Index(guid, "#"); idx != -1 {
+		guid = guid[idx+1:]
+	}
+	if idx := strings.Index(guid, "_"); idx != -1 {
+		guid = guid[:idx]
+	}
+	parts := strings.Split(guid, "-")
+	if len(parts) < 2 {
+		return "", ""
+	}
+	// Assume region is composed of the last three parts (e.g. us-west-2).
+	// This works for all region formats used in tests.
+	if len(parts) >= 3 {
+		region = strings.Join(parts[len(parts)-3:], "-")
+		serviceName = strings.Join(parts[:len(parts)-3], "-")
+	} else {
+		// fall back to last part as region
+		region = parts[len(parts)-1]
+		serviceName = strings.Join(parts[:len(parts)-1], "-")
+	}
+	return
+}

--- a/config.example.yml
+++ b/config.example.yml
@@ -24,3 +24,13 @@ services:
   - name: okta
     url: https://feeds.feedburner.com/OktaTrustRSS
     interval: 300
+  # Example AWS feeds (also added automatically with the -aws flag)
+  - name: aws_apigateway_eu-central-1
+    url: https://status.aws.amazon.com/rss/apigateway-eu-central-1.rss
+    interval: 300
+  - name: aws_connect_eu-west-2
+    url: https://status.aws.amazon.com/rss/connect-eu-west-2.rss
+    interval: 300
+  - name: aws_athena_us-west-2
+    url: https://status.aws.amazon.com/rss/athena-us-west-2.rss
+    interval: 300

--- a/main.go
+++ b/main.go
@@ -187,7 +187,8 @@ func updateServiceStatus(cfg ServiceFeed, logger *logrus.Entry) {
 
 	serviceIssueInfo.DeletePartialMatch(prometheus.Labels{"service": cfg.Name})
 	if activeItem != nil {
-		serviceIssueInfo.WithLabelValues(cfg.Name, strings.TrimSpace(activeItem.Title), activeItem.Link, activeItem.GUID).Set(1)
+		svcName, region := parseAWSGUID(activeItem.GUID)
+		serviceIssueInfo.WithLabelValues(cfg.Name, svcName, region, strings.TrimSpace(activeItem.Title), activeItem.Link, activeItem.GUID).Set(1)
 	}
 
 	for _, s := range []string{"ok", "service_issue", "outage"} {

--- a/metrics.go
+++ b/metrics.go
@@ -24,7 +24,7 @@ var (
 			Name:      "service_issue_info",
 			Help:      "Details for the currently active service issue.",
 		},
-		[]string{"service", "title", "link", "guid"},
+		[]string{"service", "service_name", "region", "title", "link", "guid"},
 	)
 )
 


### PR DESCRIPTION
## Summary
- add helper to parse AWS GUIDs for service name and region
- capture these labels when recording active AWS issues
- test the additional metric labels using sample AWS feeds
- show sample AWS feeds in the example config

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684c760a4ee88323bf012a37269cd259