### PR TITLE
Fix stale AWS status after resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,16 +40,15 @@ The `services` section lists feeds to poll. `interval` is in seconds.
 
 # HELP rss_exporter_service_issue_info Details for the currently active service issue.
 # TYPE rss_exporter_service_issue_info gauge
-rss_exporter_service_issue_info{guid="https://status.aws.amazon.com/#athena-us-west-2_1749837178",link="https://status.aws.amazon.com/",service="aws_athena_us-west-2",title="Service impact: Increased Queue Processing Time"} 1
 rss_exporter_service_issue_info{guid="https://status.openai.com//incidents/01JTS3ZKAK8KDEER57AZ0AEE6T",link="https://status.openai.com//incidents/01JTS3ZKAK8KDEER57AZ0AEE6T",service="openai",title="WhatsApp 1-800-CHATGPT partial outage"} 1
 # HELP rss_exporter_service_status Current service status parsed from configured feeds.
 # TYPE rss_exporter_service_status gauge
 rss_exporter_service_status{service="aws_apigateway_eu-central-1",state="ok"} 1
 rss_exporter_service_status{service="aws_apigateway_eu-central-1",state="outage"} 0
 rss_exporter_service_status{service="aws_apigateway_eu-central-1",state="service_issue"} 0
-rss_exporter_service_status{service="aws_athena_us-west-2",state="ok"} 0
+rss_exporter_service_status{service="aws_athena_us-west-2",state="ok"} 1
 rss_exporter_service_status{service="aws_athena_us-west-2",state="outage"} 0
-rss_exporter_service_status{service="aws_athena_us-west-2",state="service_issue"} 1
+rss_exporter_service_status{service="aws_athena_us-west-2",state="service_issue"} 0
 rss_exporter_service_status{service="aws_connect_eu-west-2",state="ok"} 1
 rss_exporter_service_status{service="aws_connect_eu-west-2",state="outage"} 0
 rss_exporter_service_status{service="aws_connect_eu-west-2",state="service_issue"} 0

--- a/aws_feed_test.go
+++ b/aws_feed_test.go
@@ -121,11 +121,11 @@ func TestUpdateServiceStatus_AWSMultiItemFeed(t *testing.T) {
 	cfg := ServiceFeed{Name: "aws-multi", URL: ts.URL, Interval: 0}
 	updateServiceStatus(cfg, logrus.NewEntry(logrus.New()))
 
-	if val := testutil.ToFloat64(serviceStatusGauge.WithLabelValues("aws-multi", "ok")); val != 0 {
-		t.Errorf("ok gauge = %v, want 0", val)
+	if val := testutil.ToFloat64(serviceStatusGauge.WithLabelValues("aws-multi", "ok")); val != 1 {
+		t.Errorf("ok gauge = %v, want 1", val)
 	}
-	if val := testutil.ToFloat64(serviceStatusGauge.WithLabelValues("aws-multi", "service_issue")); val != 1 {
-		t.Errorf("service_issue gauge = %v, want 1", val)
+	if val := testutil.ToFloat64(serviceStatusGauge.WithLabelValues("aws-multi", "service_issue")); val != 0 {
+		t.Errorf("service_issue gauge = %v, want 0", val)
 	}
 	if val := testutil.ToFloat64(serviceStatusGauge.WithLabelValues("aws-multi", "outage")); val != 0 {
 		t.Errorf("outage gauge = %v, want 0", val)

--- a/main.go
+++ b/main.go
@@ -178,6 +178,12 @@ func updateServiceStatus(cfg ServiceFeed, logger *logrus.Entry) {
 			seen[key] = struct{}{}
 		}
 		_, st, active := extractServiceStatus(item)
+		if st == "resolved" {
+			// issue has been resolved; ignore older items
+			state = "ok"
+			activeItem = nil
+			break
+		}
 		if active {
 			state = st
 			activeItem = item


### PR DESCRIPTION
## Summary
- stop treating old AWS incidents as active after a RESOLVED item
- adjust multi-item AWS test for the new logic
- update example metrics in README

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684c78e22b6c832385b69c77f41f121b