### PR TITLE
Add customer label for metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,12 @@ listen_port: 9091
 log_level: info
 services:
   - name: gcp
+    # customer defaults to the service name
     url: https://status.cloud.google.com/en/feed.atom
     interval: 300
-  - name: aws
-    url: https://status.aws.amazon.com/rss/all.rss
+  - name: Vattenfall-gcp
+    customer: Vattenfall
+    url: https://status.cloud.google.com/en/vattenfall-specfic-feed.atom
     interval: 300
 ```
 
@@ -34,19 +36,19 @@ The `services` section lists feeds to poll. `interval` is in seconds.
 
 ## Exposed Metrics
 
-* `rss_exporter_service_status{service="<name>",state="<status>"}` - Current state of each service (`ok`, `service_issue`, `outage`).
-* `rss_exporter_service_issue_info{service="<name>",title="<item_title>",link="<item_link>",guid="<item_guid>"}` - Set to `1` while a service reports an active issue.
+* `rss_exporter_service_status{service="<name>",customer="<customer>",state="<status>"}` - Current state of each service (`ok`, `service_issue`, `outage`).
+* `rss_exporter_service_issue_info{service="<name>",customer="<customer>",title="<item_title>",link="<item_link>",guid="<item_guid>"}` - Set to `1` while a service reports an active issue.
 
 ## Example output:
 
 # HELP rss_exporter_service_issue_info Details for the currently active service issue.
 # TYPE rss_exporter_service_issue_info gauge
-rss_exporter_service_issue_info{guid="https://status.openai.com//incidents/01JTS3ZKAK8KDEER57AZ0AEE6T",link="https://status.openai.com//incidents/01JTS3ZKAK8KDEER57AZ0AEE6T",service="openai",title="WhatsApp 1-800-CHATGPT partial outage"} 1
+rss_exporter_service_issue_info{guid="https://status.openai.com//incidents/01JTS3ZKAK8KDEER57AZ0AEE6T",link="https://status.openai.com//incidents/01JTS3ZKAK8KDEER57AZ0AEE6T",service="openai",customer="openai",title="WhatsApp 1-800-CHATGPT partial outage"} 1
 # HELP rss_exporter_service_status Current service status parsed from configured feeds.
 # TYPE rss_exporter_service_status gauge
-rss_exporter_service_status{service="aws_apigateway_eu-central-1",state="ok"} 1
-rss_exporter_service_status{service="aws_apigateway_eu-central-1",state="outage"} 0
-rss_exporter_service_status{service="aws_apigateway_eu-central-1",state="service_issue"} 0
+rss_exporter_service_status{service="aws_apigateway_eu-central-1",customer="aws_apigateway_eu-central-1",state="ok"} 1
+rss_exporter_service_status{service="aws_apigateway_eu-central-1",customer="aws_apigateway_eu-central-1",state="outage"} 0
+rss_exporter_service_status{service="aws_apigateway_eu-central-1",customer="aws_apigateway_eu-central-1",state="service_issue"} 0
 rss_exporter_service_status{service="aws_athena_us-west-2",state="ok"} 1
 rss_exporter_service_status{service="aws_athena_us-west-2",state="outage"} 0
 rss_exporter_service_status{service="aws_athena_us-west-2",state="service_issue"} 0

--- a/aws_feed_test.go
+++ b/aws_feed_test.go
@@ -49,13 +49,13 @@ func TestUpdateServiceStatus_AWSFeed(t *testing.T) {
 	cfg := ServiceFeed{Name: "aws", URL: ts.URL, Interval: 0}
 	updateServiceStatus(cfg, logrus.NewEntry(logrus.New()))
 
-	if val := testutil.ToFloat64(serviceStatusGauge.WithLabelValues("aws", "ok")); val != 1 {
+	if val := testutil.ToFloat64(serviceStatusGauge.WithLabelValues("aws", "aws", "ok")); val != 1 {
 		t.Errorf("ok gauge = %v, want 1", val)
 	}
-	if val := testutil.ToFloat64(serviceStatusGauge.WithLabelValues("aws", "service_issue")); val != 0 {
+	if val := testutil.ToFloat64(serviceStatusGauge.WithLabelValues("aws", "aws", "service_issue")); val != 0 {
 		t.Errorf("service_issue gauge = %v, want 0", val)
 	}
-	if val := testutil.ToFloat64(serviceStatusGauge.WithLabelValues("aws", "outage")); val != 0 {
+	if val := testutil.ToFloat64(serviceStatusGauge.WithLabelValues("aws", "aws", "outage")); val != 0 {
 		t.Errorf("outage gauge = %v, want 0", val)
 	}
 }
@@ -72,13 +72,13 @@ func TestUpdateServiceStatus_AWSAthenaIssueFeed(t *testing.T) {
 	cfg := ServiceFeed{Name: "aws-athena", URL: ts.URL, Interval: 0}
 	updateServiceStatus(cfg, logrus.NewEntry(logrus.New()))
 
-	if val := testutil.ToFloat64(serviceStatusGauge.WithLabelValues("aws-athena", "ok")); val != 0 {
+	if val := testutil.ToFloat64(serviceStatusGauge.WithLabelValues("aws-athena", "aws-athena", "ok")); val != 0 {
 		t.Errorf("ok gauge = %v, want 0", val)
 	}
-	if val := testutil.ToFloat64(serviceStatusGauge.WithLabelValues("aws-athena", "service_issue")); val != 1 {
+	if val := testutil.ToFloat64(serviceStatusGauge.WithLabelValues("aws-athena", "aws-athena", "service_issue")); val != 1 {
 		t.Errorf("service_issue gauge = %v, want 1", val)
 	}
-	if val := testutil.ToFloat64(serviceStatusGauge.WithLabelValues("aws-athena", "outage")); val != 0 {
+	if val := testutil.ToFloat64(serviceStatusGauge.WithLabelValues("aws-athena", "aws-athena", "outage")); val != 0 {
 		t.Errorf("outage gauge = %v, want 0", val)
 	}
 }
@@ -97,6 +97,7 @@ func TestServiceIssueInfoMetric(t *testing.T) {
 	updateServiceStatus(cfg, logrus.NewEntry(logrus.New()))
 
 	val := testutil.ToFloat64(serviceIssueInfo.WithLabelValues(
+		"aws-athena",
 		"aws-athena",
 		"athena",
 		"us-west-2",
@@ -121,13 +122,13 @@ func TestUpdateServiceStatus_AWSMultiItemFeed(t *testing.T) {
 	cfg := ServiceFeed{Name: "aws-multi", URL: ts.URL, Interval: 0}
 	updateServiceStatus(cfg, logrus.NewEntry(logrus.New()))
 
-	if val := testutil.ToFloat64(serviceStatusGauge.WithLabelValues("aws-multi", "ok")); val != 1 {
+	if val := testutil.ToFloat64(serviceStatusGauge.WithLabelValues("aws-multi", "aws-multi", "ok")); val != 1 {
 		t.Errorf("ok gauge = %v, want 1", val)
 	}
-	if val := testutil.ToFloat64(serviceStatusGauge.WithLabelValues("aws-multi", "service_issue")); val != 0 {
+	if val := testutil.ToFloat64(serviceStatusGauge.WithLabelValues("aws-multi", "aws-multi", "service_issue")); val != 0 {
 		t.Errorf("service_issue gauge = %v, want 0", val)
 	}
-	if val := testutil.ToFloat64(serviceStatusGauge.WithLabelValues("aws-multi", "outage")); val != 0 {
+	if val := testutil.ToFloat64(serviceStatusGauge.WithLabelValues("aws-multi", "aws-multi", "outage")); val != 0 {
 		t.Errorf("outage gauge = %v, want 0", val)
 	}
 }
@@ -154,17 +155,18 @@ func TestUpdateServiceStatus_AWSOutageFeed(t *testing.T) {
 	cfg := ServiceFeed{Name: "aws-ec2", URL: ts.URL, Interval: 0}
 	updateServiceStatus(cfg, logrus.NewEntry(logrus.New()))
 
-	if val := testutil.ToFloat64(serviceStatusGauge.WithLabelValues("aws-ec2", "ok")); val != 0 {
+	if val := testutil.ToFloat64(serviceStatusGauge.WithLabelValues("aws-ec2", "aws-ec2", "ok")); val != 0 {
 		t.Errorf("ok gauge = %v, want 0", val)
 	}
-	if val := testutil.ToFloat64(serviceStatusGauge.WithLabelValues("aws-ec2", "service_issue")); val != 0 {
+	if val := testutil.ToFloat64(serviceStatusGauge.WithLabelValues("aws-ec2", "aws-ec2", "service_issue")); val != 0 {
 		t.Errorf("service_issue gauge = %v, want 0", val)
 	}
-	if val := testutil.ToFloat64(serviceStatusGauge.WithLabelValues("aws-ec2", "outage")); val != 1 {
+	if val := testutil.ToFloat64(serviceStatusGauge.WithLabelValues("aws-ec2", "aws-ec2", "outage")); val != 1 {
 		t.Errorf("outage gauge = %v, want 1", val)
 	}
 
 	val := testutil.ToFloat64(serviceIssueInfo.WithLabelValues(
+		"aws-ec2",
 		"aws-ec2",
 		"ec2",
 		"us-west-2",

--- a/config.example.yml
+++ b/config.example.yml
@@ -7,6 +7,8 @@ log_level: info
 
 services:
   - name: gcp
+    # customer defaults to the service name when omitted
+    # customer: gcp
     url: https://status.cloud.google.com/en/feed.atom
     interval: 300
   - name: genesys-cloud
@@ -20,6 +22,10 @@ services:
     interval: 300
   - name: openai
     url: https://status.openai.com/history.atom
+    interval: 300
+  - name: Vattenfall-gcp
+    customer: Vattenfall
+    url: https://status.cloud.google.com/en/vattenfall-specfic-feed.atom
     interval: 300
   - name: okta
     url: https://feeds.feedburner.com/OktaTrustRSS

--- a/gcp_feed_test.go
+++ b/gcp_feed_test.go
@@ -85,13 +85,13 @@ func TestUpdateServiceStatus_GCPFeed(t *testing.T) {
 	cfg := ServiceFeed{Name: "gcp", URL: ts.URL, Interval: 0}
 	updateServiceStatus(cfg, logrus.NewEntry(logrus.New()))
 
-	if val := testutil.ToFloat64(serviceStatusGauge.WithLabelValues("gcp", "ok")); val != 1 {
+	if val := testutil.ToFloat64(serviceStatusGauge.WithLabelValues("gcp", "gcp", "ok")); val != 1 {
 		t.Errorf("ok gauge = %v, want 1", val)
 	}
-	if val := testutil.ToFloat64(serviceStatusGauge.WithLabelValues("gcp", "service_issue")); val != 0 {
+	if val := testutil.ToFloat64(serviceStatusGauge.WithLabelValues("gcp", "gcp", "service_issue")); val != 0 {
 		t.Errorf("service_issue gauge = %v, want 0", val)
 	}
-	if val := testutil.ToFloat64(serviceStatusGauge.WithLabelValues("gcp", "outage")); val != 0 {
+	if val := testutil.ToFloat64(serviceStatusGauge.WithLabelValues("gcp", "gcp", "outage")); val != 0 {
 		t.Errorf("outage gauge = %v, want 0", val)
 	}
 }
@@ -125,13 +125,13 @@ func TestUpdateServiceStatus_GCPResolvedThenUpdate(t *testing.T) {
 	cfg := ServiceFeed{Name: "gcp", URL: ts.URL, Interval: 0}
 	updateServiceStatus(cfg, logrus.NewEntry(logrus.New()))
 
-	if val := testutil.ToFloat64(serviceStatusGauge.WithLabelValues("gcp", "ok")); val != 1 {
+	if val := testutil.ToFloat64(serviceStatusGauge.WithLabelValues("gcp", "gcp", "ok")); val != 1 {
 		t.Errorf("ok gauge = %v, want 1", val)
 	}
-	if val := testutil.ToFloat64(serviceStatusGauge.WithLabelValues("gcp", "service_issue")); val != 0 {
+	if val := testutil.ToFloat64(serviceStatusGauge.WithLabelValues("gcp", "gcp", "service_issue")); val != 0 {
 		t.Errorf("service_issue gauge = %v, want 0", val)
 	}
-	if val := testutil.ToFloat64(serviceStatusGauge.WithLabelValues("gcp", "outage")); val != 0 {
+	if val := testutil.ToFloat64(serviceStatusGauge.WithLabelValues("gcp", "gcp", "outage")); val != 0 {
 		t.Errorf("outage gauge = %v, want 0", val)
 	}
 }

--- a/genesys_feed_test.go
+++ b/genesys_feed_test.go
@@ -31,13 +31,13 @@ func TestUpdateServiceStatus_GenesysFeed(t *testing.T) {
 	cfg := ServiceFeed{Name: "genesys-cloud", URL: ts.URL, Interval: 0}
 	updateServiceStatus(cfg, logrus.NewEntry(logrus.New()))
 
-	if val := testutil.ToFloat64(serviceStatusGauge.WithLabelValues("genesys-cloud", "ok")); val != 1 {
+	if val := testutil.ToFloat64(serviceStatusGauge.WithLabelValues("genesys-cloud", "genesys-cloud", "ok")); val != 1 {
 		t.Errorf("ok gauge = %v, want 1", val)
 	}
-	if val := testutil.ToFloat64(serviceStatusGauge.WithLabelValues("genesys-cloud", "service_issue")); val != 0 {
+	if val := testutil.ToFloat64(serviceStatusGauge.WithLabelValues("genesys-cloud", "genesys-cloud", "service_issue")); val != 0 {
 		t.Errorf("service_issue gauge = %v, want 0", val)
 	}
-	if val := testutil.ToFloat64(serviceStatusGauge.WithLabelValues("genesys-cloud", "outage")); val != 0 {
+	if val := testutil.ToFloat64(serviceStatusGauge.WithLabelValues("genesys-cloud", "genesys-cloud", "outage")); val != 0 {
 		t.Errorf("outage gauge = %v, want 0", val)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -32,6 +32,7 @@ type Config struct {
 
 type ServiceFeed struct {
 	Name     string `yaml:"name"`
+	Customer string `yaml:"customer"`
 	URL      string `yaml:"url"`
 	Interval int    `yaml:"interval"`
 }
@@ -107,6 +108,9 @@ func loadConfig(configFile string) (cfg Config, err error) {
 	for i := range cfg.Services {
 		if cfg.Services[i].Interval <= 0 {
 			cfg.Services[i].Interval = 300
+		}
+		if cfg.Services[i].Customer == "" {
+			cfg.Services[i].Customer = cfg.Services[i].Name
 		}
 	}
 
@@ -185,10 +189,15 @@ func updateServiceStatus(cfg ServiceFeed, logger *logrus.Entry) {
 		}
 	}
 
-	serviceIssueInfo.DeletePartialMatch(prometheus.Labels{"service": cfg.Name})
+	cust := cfg.Customer
+	if cust == "" {
+		cust = cfg.Name
+	}
+
+	serviceIssueInfo.DeletePartialMatch(prometheus.Labels{"service": cfg.Name, "customer": cust})
 	if activeItem != nil {
 		svcName, region := parseAWSGUID(activeItem.GUID)
-		serviceIssueInfo.WithLabelValues(cfg.Name, svcName, region, strings.TrimSpace(activeItem.Title), activeItem.Link, activeItem.GUID).Set(1)
+		serviceIssueInfo.WithLabelValues(cfg.Name, cust, svcName, region, strings.TrimSpace(activeItem.Title), activeItem.Link, activeItem.GUID).Set(1)
 	}
 
 	for _, s := range []string{"ok", "service_issue", "outage"} {
@@ -196,7 +205,7 @@ func updateServiceStatus(cfg ServiceFeed, logger *logrus.Entry) {
 		if s == state {
 			val = 1
 		}
-		serviceStatusGauge.WithLabelValues(cfg.Name, s).Set(val)
+		serviceStatusGauge.WithLabelValues(cfg.Name, cust, s).Set(val)
 	}
 }
 

--- a/metrics.go
+++ b/metrics.go
@@ -16,7 +16,7 @@ var (
 			Name:      "service_status",
 			Help:      "Current service status parsed from configured feeds.",
 		},
-		[]string{"service", "state"},
+		[]string{"service", "customer", "state"},
 	)
 	serviceIssueInfo = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -24,7 +24,7 @@ var (
 			Name:      "service_issue_info",
 			Help:      "Details for the currently active service issue.",
 		},
-		[]string{"service", "service_name", "region", "title", "link", "guid"},
+		[]string{"service", "customer", "service_name", "region", "title", "link", "guid"},
 	)
 )
 

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestMetricsEndpoint(t *testing.T) {
 	serviceStatusGauge.Reset()
-	serviceStatusGauge.WithLabelValues("test", "ok").Set(1)
+	serviceStatusGauge.WithLabelValues("test", "test", "ok").Set(1)
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", promhttp.Handler())
 

--- a/openai_feed_test.go
+++ b/openai_feed_test.go
@@ -53,13 +53,13 @@ func TestUpdateServiceStatus_OpenAIResolved(t *testing.T) {
 	cfg := ServiceFeed{Name: "openai", URL: ts.URL, Interval: 0}
 	updateServiceStatus(cfg, logrus.NewEntry(logrus.New()))
 
-	if val := testutil.ToFloat64(serviceStatusGauge.WithLabelValues("openai", "ok")); val != 1 {
+	if val := testutil.ToFloat64(serviceStatusGauge.WithLabelValues("openai", "openai", "ok")); val != 1 {
 		t.Errorf("ok gauge = %v, want 1", val)
 	}
-	if val := testutil.ToFloat64(serviceStatusGauge.WithLabelValues("openai", "service_issue")); val != 0 {
+	if val := testutil.ToFloat64(serviceStatusGauge.WithLabelValues("openai", "openai", "service_issue")); val != 0 {
 		t.Errorf("service_issue gauge = %v, want 0", val)
 	}
-	if val := testutil.ToFloat64(serviceStatusGauge.WithLabelValues("openai", "outage")); val != 0 {
+	if val := testutil.ToFloat64(serviceStatusGauge.WithLabelValues("openai", "openai", "outage")); val != 0 {
 		t.Errorf("outage gauge = %v, want 0", val)
 	}
 }


### PR DESCRIPTION
## Summary
- add optional customer field to service config
- expose `customer` label in Prometheus metrics
- default customer label to service name if not supplied
- update config example and README
- adjust tests for new label

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684c8099cc288323a42b4fa73292aef2