### PR TITLE
Make customer label optional in metrics

### DIFF
--- a/metrics_test.go
+++ b/metrics_test.go
@@ -10,8 +10,11 @@ import (
 )
 
 func TestMetricsEndpoint(t *testing.T) {
-	serviceStatusGauge.Reset()
-	serviceStatusGauge.WithLabelValues("test", "test", "ok").Set(1)
+	metricsMu.Lock()
+	metricsData = map[string]*serviceMetrics{
+		"test": {State: "ok"},
+	}
+	metricsMu.Unlock()
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", promhttp.Handler())
 


### PR DESCRIPTION
## Summary
- allow missing `customer` configuration
- track service state using custom collector rather than GaugeVecs
- remove automatic `customer` defaulting
- update tests for new metrics collector

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684c82423e6c8323a2ed46326acdecd1