### PR TITLE
Implement feed deduplication

### DIFF
--- a/main.go
+++ b/main.go
@@ -166,7 +166,7 @@ func updateServiceStatus(cfg ServiceFeed, logger *logrus.Entry) {
 	var svcName, region string
 	seen := make(map[string]struct{})
 	for _, item := range feed.Items {
-		key := incidentKey(item)
+		key := parser.IncidentKey(item)
 		if key != "" {
 			if _, ok := seen[key]; ok {
 				continue
@@ -210,11 +210,4 @@ func updateServiceStatus(cfg ServiceFeed, logger *logrus.Entry) {
 		Issue:    info,
 	}
 	metricsMu.Unlock()
-}
-
-func incidentKey(item *gofeed.Item) string {
-	if strings.Contains(item.Link, "status.cloud.google.com/incidents/") {
-		return item.Link
-	}
-	return ""
 }

--- a/roadmap.md
+++ b/roadmap.md
@@ -15,7 +15,7 @@ This document outlines the planned enhancements to transform RSS Exporter into a
 - [x] Provide an interface so each provider reports service name, region, and status consistently
 
 ### Feed Deduplication
-- [ ] Enhance `incidentKey` or create provider-specific deduplication logic for repeated incident entries
+- [x] Enhance `incidentKey` or create provider-specific deduplication logic for repeated incident entries
 
 ### Error Handling & Retries
 - [ ] Add retry logic with exponential backoff around feed fetching


### PR DESCRIPTION
## Summary
- add provider-specific incident key handling for deduplication
- integrate IncidentKey into service update loop
- mark Feed Deduplication item complete in roadmap

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684c88a2a700832396d1f52e1512f2ed