### PR TITLE
Add provider field for parser selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,16 +23,20 @@ listen_port: 9091
 log_level: info
 services:
   - name: gcp
+    provider: gcp
     # customer defaults to the service name
     url: https://status.cloud.google.com/en/feed.atom
     interval: 300
   - name: Vattenfall-gcp
+    provider: gcp
     customer: Vattenfall
     url: https://status.cloud.google.com/en/vattenfall-specfic-feed.atom
     interval: 300
 ```
 
-The `services` section lists feeds to poll. `interval` is in seconds.
+The `services` section lists feeds to poll. `interval` is in seconds. Each entry
+can optionally specify a `provider` to explicitly select the parser used for
+that service. When omitted, the provider is inferred from the service name.
 
 ## Exposed Metrics
 

--- a/config.example.yml
+++ b/config.example.yml
@@ -7,30 +7,38 @@ log_level: info
 
 services:
   - name: gcp
+    provider: gcp
     # customer defaults to the service name when omitted
     # customer: gcp
     url: https://status.cloud.google.com/en/feed.atom
     interval: 300
   - name: genesys-cloud
+    provider: genesyscloud
     url: https://status.mypurecloud.com/history.atom
     interval: 300
   - name: azure
+    provider: azure
     url: https://azurestatuscdn.azureedge.net/en-gb/status/feed
     interval: 300
   - name: cloudflare
+    provider: cloudflare
     url: https://www.cloudflarestatus.com/history.atom
     interval: 300
   - name: openai
+    provider: openai
     url: https://status.openai.com/history.atom
     interval: 300
   - name: Vattenfall-gcp
+    provider: gcp
     customer: Vattenfall
     url: https://status.cloud.google.com/en/vattenfall-specfic-feed.atom
     interval: 300
   - name: okta
+    provider: okta
     url: https://feeds.feedburner.com/OktaTrustRSS
     interval: 300
   # Example AWS feed
   - name: aws
+    provider: aws
     url: https://status.aws.amazon.com/rss/all.rss
     interval: 300

--- a/main.go
+++ b/main.go
@@ -35,6 +35,7 @@ type Config struct {
 
 type ServiceFeed struct {
 	Name     string `yaml:"name"`
+	Provider string `yaml:"provider"`
 	Customer string `yaml:"customer"`
 	URL      string `yaml:"url"`
 	Interval int    `yaml:"interval"`
@@ -203,7 +204,7 @@ func updateServiceStatus(cfg ServiceFeed, logger *logrus.Entry) {
 
 	state := "ok"
 	var activeItem *gofeed.Item
-	parser := parserForService(cfg.Name)
+	parser := parserForService(cfg.Provider, cfg.Name)
 	var svcName, region string
 	seen := make(map[string]struct{})
 	for _, item := range feed.Items {

--- a/provider.go
+++ b/provider.go
@@ -101,8 +101,24 @@ func (genericParser) IncidentKey(item *gofeed.Item) string {
 	return strings.TrimSpace(item.Title)
 }
 
-// parserForService selects a parser based on the configured service name.
-func parserForService(service string) ItemParser {
+// parserForService selects a parser based on the provider or service name.
+func parserForService(provider, service string) ItemParser {
+	p := strings.ToLower(provider)
+	switch p {
+	case "aws":
+		return awsParser{}
+	case "gcp":
+		return gcpParser{}
+	case "azure":
+		return azureParser{}
+	case "":
+		// fall back to service name when provider not set
+	default:
+		if p != "" {
+			return genericParser{}
+		}
+	}
+
 	svc := strings.ToLower(service)
 	switch {
 	case strings.Contains(svc, "aws"):


### PR DESCRIPTION
## Summary
- add `provider` to `ServiceFeed` config struct
- select parsers using the provider value
- document provider usage in README and example config

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684c8f9f194083239d70d1de7126bc7c