### PR TITLE
Cleanup unused function and modernize tests

### DIFF
--- a/internal/exporter/aws_feed_test.go
+++ b/internal/exporter/aws_feed_test.go
@@ -1,9 +1,9 @@
 package exporter
 
 import (
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/sirupsen/logrus"
@@ -11,7 +11,7 @@ import (
 
 func loadAWSFeed(t *testing.T) []byte {
 	t.Helper()
-	data, err := ioutil.ReadFile("testdata/aws_feed.rss")
+	data, err := os.ReadFile("testdata/aws_feed.rss")
 	if err != nil {
 		t.Fatalf("read feed: %v", err)
 	}
@@ -20,7 +20,7 @@ func loadAWSFeed(t *testing.T) []byte {
 
 func loadAWSAthenaIssueFeed(t *testing.T) []byte {
 	t.Helper()
-	data, err := ioutil.ReadFile("testdata/aws_athena_us_west_2_issue.rss")
+	data, err := os.ReadFile("testdata/aws_athena_us_west_2_issue.rss")
 	if err != nil {
 		t.Fatalf("read feed: %v", err)
 	}
@@ -29,7 +29,7 @@ func loadAWSAthenaIssueFeed(t *testing.T) []byte {
 
 func loadAWSMultiItemFeed(t *testing.T) []byte {
 	t.Helper()
-	data, err := ioutil.ReadFile("testdata/aws_multi_item.rss")
+	data, err := os.ReadFile("testdata/aws_multi_item.rss")
 	if err != nil {
 		t.Fatalf("read feed: %v", err)
 	}
@@ -133,7 +133,7 @@ func TestUpdateServiceStatus_AWSMultiItemFeed(t *testing.T) {
 
 func loadAWSOutageFeed(t *testing.T) []byte {
 	t.Helper()
-	data, err := ioutil.ReadFile("testdata/aws_outage.rss")
+	data, err := os.ReadFile("testdata/aws_outage.rss")
 	if err != nil {
 		t.Fatalf("read feed: %v", err)
 	}

--- a/internal/exporter/azure_feed_test.go
+++ b/internal/exporter/azure_feed_test.go
@@ -1,9 +1,9 @@
 package exporter
 
 import (
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/sirupsen/logrus"
@@ -11,7 +11,7 @@ import (
 
 func loadAzureIssueFeed(t *testing.T) []byte {
 	t.Helper()
-	data, err := ioutil.ReadFile("testdata/azure_issue.rss")
+	data, err := os.ReadFile("testdata/azure_issue.rss")
 	if err != nil {
 		t.Fatalf("read feed: %v", err)
 	}

--- a/internal/exporter/gcp_feed_test.go
+++ b/internal/exporter/gcp_feed_test.go
@@ -1,9 +1,9 @@
 package exporter
 
 import (
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 
@@ -13,7 +13,7 @@ import (
 
 func loadGCPFeed(t *testing.T) *gofeed.Feed {
 	t.Helper()
-	data, err := ioutil.ReadFile("testdata/gcp_feed.atom")
+	data, err := os.ReadFile("testdata/gcp_feed.atom")
 	if err != nil {
 		t.Fatalf("read feed: %v", err)
 	}
@@ -26,20 +26,7 @@ func loadGCPFeed(t *testing.T) *gofeed.Feed {
 
 func loadGCPUpdateFeed(t *testing.T) *gofeed.Feed {
 	t.Helper()
-	data, err := ioutil.ReadFile("testdata/gcp_update_resolved.atom")
-	if err != nil {
-		t.Fatalf("read feed: %v", err)
-	}
-	feed, err := gofeed.NewParser().ParseString(string(data))
-	if err != nil {
-		t.Fatalf("parse feed: %v", err)
-	}
-	return feed
-}
-
-func loadGCPResolvedThenUpdateFeed(t *testing.T) *gofeed.Feed {
-	t.Helper()
-	data, err := ioutil.ReadFile("testdata/gcp_resolved_then_update.atom")
+	data, err := os.ReadFile("testdata/gcp_update_resolved.atom")
 	if err != nil {
 		t.Fatalf("read feed: %v", err)
 	}
@@ -70,7 +57,7 @@ func TestExtractServiceStatus_GCPFeed(t *testing.T) {
 
 func TestUpdateServiceStatus_GCPFeed(t *testing.T) {
 	// serve the feed via test server
-	data, err := ioutil.ReadFile("testdata/gcp_feed.atom")
+	data, err := os.ReadFile("testdata/gcp_feed.atom")
 	if err != nil {
 		t.Fatalf("read feed: %v", err)
 	}
@@ -110,7 +97,7 @@ func TestExtractServiceStatus_GCPUpdateFeed(t *testing.T) {
 }
 
 func TestUpdateServiceStatus_GCPResolvedThenUpdate(t *testing.T) {
-	data, err := ioutil.ReadFile("testdata/gcp_resolved_then_update.atom")
+	data, err := os.ReadFile("testdata/gcp_resolved_then_update.atom")
 	if err != nil {
 		t.Fatalf("read feed: %v", err)
 	}

--- a/internal/exporter/genesys_feed_test.go
+++ b/internal/exporter/genesys_feed_test.go
@@ -1,9 +1,9 @@
 package exporter
 
 import (
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/sirupsen/logrus"
@@ -11,7 +11,7 @@ import (
 
 func loadGenesysFeed(t *testing.T) []byte {
 	t.Helper()
-	data, err := ioutil.ReadFile("testdata/genesys_feed.atom")
+	data, err := os.ReadFile("testdata/genesys_feed.atom")
 	if err != nil {
 		t.Fatalf("read feed: %v", err)
 	}

--- a/internal/exporter/openai_feed_test.go
+++ b/internal/exporter/openai_feed_test.go
@@ -1,9 +1,9 @@
 package exporter
 
 import (
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/mmcdole/gofeed"
@@ -12,7 +12,7 @@ import (
 
 func loadOpenAIResolvedFeed(t *testing.T) *gofeed.Feed {
 	t.Helper()
-	data, err := ioutil.ReadFile("testdata/openai_resolved.atom")
+	data, err := os.ReadFile("testdata/openai_resolved.atom")
 	if err != nil {
 		t.Fatalf("read feed: %v", err)
 	}
@@ -38,7 +38,7 @@ func TestExtractServiceStatus_OpenAIResolved(t *testing.T) {
 }
 
 func TestUpdateServiceStatus_OpenAIResolved(t *testing.T) {
-	data, err := ioutil.ReadFile("testdata/openai_resolved.atom")
+	data, err := os.ReadFile("testdata/openai_resolved.atom")
 	if err != nil {
 		t.Fatalf("read feed: %v", err)
 	}


### PR DESCRIPTION
## Summary
- remove a leftover helper in `gcp_feed_test.go`
- replace deprecated `ioutil` package with `os.ReadFile` in tests

## Testing
- `go test ./...`
- `staticcheck ./...`


------
https://chatgpt.com/codex/tasks/task_e_684c9fa95a588323a8d45314aa3d9d3f