### PR TITLE
Fix default listen port

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -7,7 +7,7 @@ The exporter is configured via a YAML file passed with the `-config` flag. The d
 | Field           | Description                         | Default |
 |-----------------|-------------------------------------|---------|
 | `listen_address`| Address to bind the HTTP server     | `0.0.0.0` |
-| `listen_port`   | Port for the HTTP server            | `9191` |
+| `listen_port`   | Port for the HTTP server            | `9091` |
 | `log_level`     | Log verbosity (`trace`, `debug`, `info`, `warn`) | `info` |
 | `services`      | List of RSS/Atom feeds to monitor   | - |
 

--- a/internal/exporter/config.go
+++ b/internal/exporter/config.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	defaultListenAddress = "0.0.0.0"
-	defaultListenPort    = 9191
+	defaultListenPort    = 9091
 	defaultConfigFile    = "config.yml"
 )
 


### PR DESCRIPTION
## Summary
- match docs and code to the same listen port

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684ca4cc4aa8832395e74ee131e8615b