### PR TITLE
Add sample Grafana dashboards

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,4 +6,5 @@ This folder contains developer resources for **RSS Exporter**.
 - [Developer Guide](developer-guide.md)
 - [Configuration](configuration.md)
 - [Metrics](metrics.md)
+- [Grafana Dashboards](grafana/README.md)
 

--- a/docs/grafana/README.md
+++ b/docs/grafana/README.md
@@ -1,0 +1,11 @@
+# Grafana Dashboards
+
+This directory contains example dashboards for visualizing metrics exported by
+**RSS Exporter**.
+
+- `traffic_lights.json` – shows the status of selected services as simple
+  green/yellow/red indicators.
+- `provider_traffic_lights.json` – lets you choose a provider and displays all
+  associated services.
+
+Import these JSON files into Grafana and select your Prometheus datasource.

--- a/docs/grafana/provider_traffic_lights.json
+++ b/docs/grafana/provider_traffic_lights.json
@@ -1,0 +1,99 @@
+{
+  "id": null,
+  "uid": "rss-provider-lights",
+  "title": "RSS Exporter - Provider Overview",
+  "schemaVersion": 38,
+  "version": 1,
+  "refresh": "5m",
+  "tags": [],
+  "timezone": "browser",
+  "panels": [
+    {
+      "type": "stat",
+      "title": "$__repeat",
+      "datasource": "${Datasource}",
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "rss_exporter_service_status{service=\"$__repeat\",state=\"service_issue\"} + 2 * rss_exporter_service_status{service=\"$__repeat\",state=\"outage\"}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {"text": "OK"},
+                "1": {"text": "Issue"},
+                "2": {"text": "Outage"}
+              }
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "yellow", "value": 1},
+              {"color": "red", "value": 2}
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "orientation": "auto"
+      },
+      "gridPos": {"h": 4, "w": 4, "x": 0, "y": 0},
+      "repeat": "service",
+      "maxPerRow": 6
+    }
+  ],
+  "templating": {
+    "list": [
+      {
+        "name": "Datasource",
+        "type": "datasource",
+        "label": "Datasource",
+        "query": "prometheus",
+        "refresh": 1,
+        "hide": 0,
+        "current": {
+          "selected": false,
+          "text": "Prometheus",
+          "value": "Prometheus"
+        }
+      },
+      {
+        "name": "provider",
+        "type": "custom",
+        "label": "Provider",
+        "options": [
+          {"text": "aws", "value": "aws"},
+          {"text": "azure", "value": "azure"},
+          {"text": "gcp", "value": "gcp"},
+          {"text": "cloudflare", "value": "cloudflare"},
+          {"text": "openai", "value": "openai"},
+          {"text": "okta", "value": "okta"},
+          {"text": "genesys-cloud", "value": "genesys-cloud"}
+        ],
+        "current": {"text": "aws", "value": "aws"},
+        "includeAll": false,
+        "multi": false,
+        "hide": 0
+      },
+      {
+        "name": "service",
+        "type": "query",
+        "datasource": "${Datasource}",
+        "query": "label_values(rss_exporter_service_status{service=~\"${provider}.*\"}, service)",
+        "multi": true,
+        "includeAll": true,
+        "refresh": 1,
+        "hide": 0
+      }
+    ]
+  },
+  "time": {"from": "now-6h", "to": "now"}
+}

--- a/docs/grafana/traffic_lights.json
+++ b/docs/grafana/traffic_lights.json
@@ -1,0 +1,81 @@
+{
+  "id": null,
+  "uid": "rss-traffic-lights",
+  "title": "RSS Exporter - Service Status",
+  "schemaVersion": 38,
+  "version": 1,
+  "refresh": "5m",
+  "tags": [],
+  "timezone": "browser",
+  "panels": [
+    {
+      "type": "stat",
+      "title": "$__repeat",
+      "datasource": "${Datasource}",
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "rss_exporter_service_status{service=\"$__repeat\",state=\"service_issue\"} + 2 * rss_exporter_service_status{service=\"$__repeat\",state=\"outage\"}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {"text": "OK"},
+                "1": {"text": "Issue"},
+                "2": {"text": "Outage"}
+              }
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "yellow", "value": 1},
+              {"color": "red", "value": 2}
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "orientation": "auto"
+      },
+      "gridPos": {"h": 4, "w": 4, "x": 0, "y": 0},
+      "repeat": "service",
+      "maxPerRow": 6
+    }
+  ],
+  "templating": {
+    "list": [
+      {
+        "name": "Datasource",
+        "type": "datasource",
+        "label": "Datasource",
+        "query": "prometheus",
+        "refresh": 1,
+        "hide": 0,
+        "current": {
+          "selected": false,
+          "text": "Prometheus",
+          "value": "Prometheus"
+        }
+      },
+      {
+        "name": "service",
+        "type": "query",
+        "datasource": "${Datasource}",
+        "query": "label_values(rss_exporter_service_status, service)",
+        "multi": true,
+        "includeAll": true,
+        "refresh": 1,
+        "hide": 0
+      }
+    ]
+  },
+  "time": {"from": "now-6h", "to": "now"}
+}


### PR DESCRIPTION
## Summary
- add example Grafana dashboards for visualising service status
- document the dashboards in the docs index

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684ca8633c2483239f8ae89197d658dd