### PR TITLE
Introduce scrapers with collectors and connectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,21 +56,21 @@ services:
 ```
 
 The `services` section lists feeds to poll. `interval` is in seconds. Each entry
-can optionally specify a `provider` to explicitly select the parser used for
+can optionally specify a `provider` to explicitly select the scraper used for
 that service. When omitted, the provider is inferred from the service name.
 
 ### Provider Modules
 
-The exporter includes dedicated parsers for several cloud providers:
+The exporter includes dedicated scrapers for several cloud providers:
 
 * **aws** – parses AWS Health RSS feeds and extracts service and region.
 * **gcp** – handles Google Cloud status feeds.
 * **azure** – parses Azure status feeds and extracts service and region.
 
-Any other value falls back to the generic parser. Provider names like
-`cloudflare`, `genesyscloud`, `okta`, or `openai` all use the generic parser.
+Any other value falls back to the generic scraper. Provider names like
+`cloudflare`, `genesyscloud`, `okta`, or `openai` all use the generic collector.
 When the `provider` field is omitted, the service name is inspected to select a
-suitable parser.
+suitable scraper.
 
 ## Exposed Metrics
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -7,13 +7,15 @@ This document describes the internal structure of **RSS Exporter** and how the m
 ```
 rss-exporter/
 ├── main.go             # Application entry point
-├── internal/exporter/   # Core exporter logic
-│   ├── config.go        # Configuration loader
-│   ├── fetch.go         # Feed fetching with retries
-│   ├── provider.go      # Provider-specific parsing
-│   ├── service.go       # Feed monitoring worker
-│   ├── metrics.go       # Prometheus metrics collector
-│   └── worker.go        # Goroutine orchestration
+├── internal/exporter/  # Core exporter logic
+│   ├── config.go       # Configuration loader
+│   ├── service.go      # Feed monitoring worker
+│   ├── metrics.go      # Prometheus metrics collector
+│   └── worker.go       # Goroutine orchestration
+├── internal/collectors/ # Provider specific scrapers
+│   └── scraper.go      # Scraper implementations
+└── internal/connectors/ # Feed fetching helpers
+    └── connector.go    # HTTP connector with retries
 ```
 
 All production code lives in the `internal/exporter` package. Tests and sample feed files are kept alongside the implementation.
@@ -22,11 +24,11 @@ All production code lives in the `internal/exporter` package. Tests and sample f
 
 1. **Configuration** is loaded from YAML using `initConfig` in `config.go`.
 2. `main.go` creates a context and starts a worker goroutine for each configured feed via `StartWorkers`.
-3. Each worker continuously fetches its feed in `monitorService`. Feed retrieval is retried using exponential backoff (`fetchFeedWithRetry`).
-4. Feed items are parsed by a provider-specific parser chosen by `parserForService`. Parsed status information is stored in shared metrics structures.
+3. Each worker continuously fetches its feed in `monitorService`. Feed retrieval is retried using exponential backoff via the connector.
+4. Feed items are parsed by a provider-specific scraper chosen by `ScraperForService`. Parsed status information is stored in shared metrics structures.
 5. Prometheus metrics are exposed via the `/metrics` HTTP handler.
 
 ## Adding new providers
 
-Implement the `ItemParser` interface with `ServiceInfo` and `IncidentKey`. Update `parserForService` to return the new parser when the provider name is requested. Unit tests under `internal/exporter` demonstrate expected behaviour for existing providers.
+Implement the `Scraper` interface with `ServiceInfo` and `IncidentKey`. Update `ScraperForService` to return the new scraper when the provider name is requested. Unit tests under `internal/collectors` demonstrate expected behaviour for existing providers.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -18,7 +18,7 @@ Each entry under `services` defines a single feed.
 | Field      | Description                                                      |
 |------------|------------------------------------------------------------------|
 | `name`     | Unique identifier for the service.                               |
-| `provider` | Optional parser to use (`aws`, `gcp`, `azure`, etc.). When omitted the service name is inspected. |
+| `provider` | Optional scraper to use (`aws`, `gcp`, `azure`, etc.). When omitted the service name is inspected. |
 | `customer` | Optional customer or tenant name. Appears as a metric label.     |
 | `url`      | RSS or Atom feed URL.                                            |
 | `interval` | Polling interval in seconds (defaults to `300` when not set).    |

--- a/internal/collectors/aws_guid.go
+++ b/internal/collectors/aws_guid.go
@@ -1,15 +1,15 @@
-package exporter
+package collectors
 
 import "strings"
 
-// parseAWSGUID extracts the AWS service name and region from a GUID string.
+// ParseAWSGUID extracts the AWS service name and region from a GUID string.
 // GUIDs may appear in several formats, including:
 //
 //	https://status.aws.amazon.com/#service-region_12345
 //	arn:aws:health:region::event/AWS_SERVICE_eventid
 //
 // Unknown formats return empty strings.
-func parseAWSGUID(guid string) (serviceName, region string) {
+func ParseAWSGUID(guid string) (serviceName, region string) {
 	if idx := strings.Index(guid, "#"); idx != -1 {
 		guid = guid[idx+1:]
 	}

--- a/internal/collectors/scraper.go
+++ b/internal/collectors/scraper.go
@@ -1,4 +1,4 @@
-package exporter
+package collectors
 
 import (
 	"strings"
@@ -6,10 +6,9 @@ import (
 	"github.com/mmcdole/gofeed"
 )
 
-// ItemParser extracts provider-specific information from a feed item.
-// ItemParser extracts provider-specific information from a feed item and
+// Scraper extracts provider-specific information from a feed item and
 // also provides a deduplication key used to filter repeated entries.
-type ItemParser interface {
+type Scraper interface {
 	// ServiceInfo returns the service name and region associated with the item.
 	ServiceInfo(item *gofeed.Item) (serviceName, region string)
 	// IncidentKey returns a stable identifier for the incident represented
@@ -20,7 +19,7 @@ type ItemParser interface {
 type awsParser struct{}
 
 func (awsParser) ServiceInfo(item *gofeed.Item) (string, string) {
-	return parseAWSGUID(item.GUID)
+	return ParseAWSGUID(item.GUID)
 }
 
 func (awsParser) IncidentKey(item *gofeed.Item) string {
@@ -101,8 +100,8 @@ func (genericParser) IncidentKey(item *gofeed.Item) string {
 	return strings.TrimSpace(item.Title)
 }
 
-// parserForService selects a parser based on the provider or service name.
-func parserForService(provider, service string) ItemParser {
+// ScraperForService selects a scraper based on the provider or service name.
+func ScraperForService(provider, service string) Scraper {
 	p := strings.ToLower(provider)
 	switch p {
 	case "aws":

--- a/internal/connectors/connector.go
+++ b/internal/connectors/connector.go
@@ -1,4 +1,4 @@
-package exporter
+package connector
 
 import (
 	"context"
@@ -13,8 +13,8 @@ const (
 	defaultFetchRetries = 3
 )
 
-// fetchFeedWithRetry retrieves the feed URL with exponential backoff retries.
-func fetchFeedWithRetry(url string, logger *logrus.Entry) (*gofeed.Feed, error) {
+// FetchFeedWithRetry retrieves the feed URL with exponential backoff retries.
+func FetchFeedWithRetry(url string, logger *logrus.Entry) (*gofeed.Feed, error) {
 	backoff := time.Second
 	var lastErr error
 	for i := 1; i <= defaultFetchRetries; i++ {

--- a/internal/exporter/aws_guid_test.go
+++ b/internal/exporter/aws_guid_test.go
@@ -1,16 +1,20 @@
 package exporter
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/4O4-Not-F0und/rss-exporter/internal/collectors"
+)
 
 func TestParseAWSGUID_Basic(t *testing.T) {
-	svc, region := parseAWSGUID("https://status.aws.amazon.com/#athena-us-west-2_1234")
+	svc, region := collectors.ParseAWSGUID("https://status.aws.amazon.com/#athena-us-west-2_1234")
 	if svc != "athena" || region != "us-west-2" {
 		t.Fatalf("got %s %s", svc, region)
 	}
 }
 
 func TestParseAWSGUID_ARN(t *testing.T) {
-	svc, region := parseAWSGUID("arn:aws:health:us-east-1::event/AWS_EC2_EXAMPLE")
+	svc, region := collectors.ParseAWSGUID("arn:aws:health:us-east-1::event/AWS_EC2_EXAMPLE")
 	if svc != "ec2" || region != "us-east-1" {
 		t.Fatalf("got %s %s", svc, region)
 	}


### PR DESCRIPTION
## Summary
- add connector package for fetching feeds with retry
- introduce collectors package with provider-specific scrapers
- rename parser references in docs and code to scraper

## Testing
- `go test ./...`
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_684caba28db8832385bee5f0a9287db9