### PR TITLE
Implement step 4 tests

### DIFF
--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -20,7 +20,12 @@ The exporter relies on the minimal `monitoring-maas` framework bundled in this
 repository. Scrapers are implemented in the `collectors` package and scheduled
 via `maas.ScheduledScraper`. HTTP access is provided through a pluggable
 connector located in the `connectors` package. Tests use `MockHTTPConnector`
-with canned RSS feeds.
+with canned RSS or Atom feeds stored in `collectors/testdata`.
+
+Each unit test creates its own `MockHTTPConnector` instance and registers the
+desired feed responses. This allows the collectors to run without network
+access and ensures tests remain deterministic. To add a new scenario, place an
+example feed file in `collectors/testdata` and load it in the test suite.
 
 To build a container image:
 


### PR DESCRIPTION
## Summary
- add helper to feed_test to create exporters with custom mock feeds
- cover Azure service issue and OpenAI resolved scenarios
- document how MockHTTPConnector is used in tests

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6851b6abd2448323abb9ba75136e01d6