### PR TITLE
Align mock feeds with docs

### DIFF
--- a/cmd/mock_feeds/main.go
+++ b/cmd/mock_feeds/main.go
@@ -100,7 +100,7 @@ func azureHandler(w http.ResponseWriter, r *http.Request) {
       <title>%s: %s - %s</title>
       <link>https://status.azure.com/en-us/status</link>
       <pubDate>%s</pubDate>
-      <guid>%s</guid>
+      <guid isPermaLink="false">%s</guid>
       <description>Simulated %s for %s in %s</description>
     </item>
   </channel>
@@ -198,11 +198,12 @@ func genesysHandler(w http.ResponseWriter, r *http.Request) {
   <updated>%s</updated>
   <entry>
     <title>%s: %s</title>
-    <id>tag:status.mypurecloud.com,2005:%s</id>
+    <id>tag:status.mypurecloud.com,2005:Incident/%s</id>
+    <link href="https://status.mypurecloud.com/incidents/%s"/>
     <updated>%s</updated>
     <content type="html"><p>%s incident for %s</p></content>
   </entry>
-</feed>`, ts, status, svc, id, ts, state, svc)
+</feed>`, ts, status, svc, id, id, ts, state, svc)
 
 	w.Header().Set("Content-Type", "application/atom+xml")
 	fmt.Fprint(w, content)

--- a/collectors/testdata/azure_issue.rss
+++ b/collectors/testdata/azure_issue.rss
@@ -6,7 +6,7 @@
       <title>Service issue: Storage - East US</title>
       <link>https://status.azure.com/en-us/status</link>
       <pubDate>Fri, 13 Jun 2025 09:38:42 PDT</pubDate>
-      <guid>storage-eastus_issue</guid>
+      <guid isPermaLink="false">storage-eastus_issue</guid>
       <description>We are investigating issues with Storage in East US.</description>
     </item>
   </channel>

--- a/collectors/testdata/genesys_feed.atom
+++ b/collectors/testdata/genesys_feed.atom
@@ -9,6 +9,8 @@
 <id>tag:status.mypurecloud.com,2005:/history</id>
 <entry>
 <title>Elevated Error Rates: Text to Speech, Speech to Text, and Dialogflow ES/CX bot Integrations</title>
+<id>tag:status.mypurecloud.com,2005:Incident/mock-123</id>
+<link href="https://status.mypurecloud.com/incidents/mock-123"/>
 <updated>2025-06-12T19:36:04-04:00</updated>
 <content type="html"><p><strong>Resolved</strong> - This incident has been resolved.</p></content>
 </entry>


### PR DESCRIPTION
## Summary
- include link and id fields in Genesys mock feed
- mark Azure GUIDs as non-permalink
- update static test feeds to include these fields

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68761cfc42bc8323b9f157bfb18d6d46