### PR TITLE
Add Genesys parser for service and region labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,10 @@ The exporter includes dedicated scrapers for several cloud providers:
 * **gcp** – handles Google Cloud status feeds.
 * **azure** – parses Azure status feeds and extracts service and region.
 * **twilio** – parses Twilio status feeds and surfaces the affected region and product for incidents and scheduled maintenance.
+* **genesyscloud** – extracts Genesys service and regional information, including multi-region incidents when available.
 
 Any other value falls back to the generic scraper. Provider names like
-`cloudflare`, `genesyscloud`, `okta`, or `openai` all use the generic collector.
+`cloudflare`, `okta`, or `openai` all use the generic collector.
 When the `provider` field is omitted, the service name is inspected to select a
 suitable scraper.
 

--- a/collectors/feed_test.go
+++ b/collectors/feed_test.go
@@ -90,6 +90,12 @@ func (s *FeedTestSuite) TestGenesysIdentifiedIncident() {
 		"genesys_test_service_status{customer=\"\",service=\"genesys-test\",state=\"service_issue\"} 1\n"
 	err := testutil.CollectAndCompare(s.Exporter, strings.NewReader(expected), "genesys-test_service_status")
 	s.NoError(err)
+
+	expectedInfo := "# HELP genesys_test_service_issue_info Details for active service issues\n" +
+		"# TYPE genesys_test_service_issue_info gauge\n" +
+		"genesys_test_service_issue_info{customer=\"\",guid=\"tag:status.mypurecloud.com,2005:Incident/26815638\",link=\"https://status.mypurecloud.com/incidents/nj3rdcjrgh02\",region=\"multiple-regions\",service=\"genesys-test\",service_name=\"multiple-services\",title=\"Americas (US East) Incident\"} 1\n"
+	err = testutil.CollectAndCompare(s.Exporter, strings.NewReader(expectedInfo), "genesys-test_service_issue_info")
+	s.NoError(err)
 }
 
 func (s *FeedTestSuite) TestTwilioScheduledMaintenance() {


### PR DESCRIPTION
## Summary
- add a Genesys-specific parser that derives service and region labels, including multi-region incidents
- extend Genesys feed coverage with service_issue_info expectations and update provider documentation

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68f61cd9ae048323897c29ea4326853b